### PR TITLE
fix: require spacing from curly braces in objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ module.exports = {
     'no-with': 'error',
     'nonblock-statement-body-position': [2, 'below'],
     'object-curly-newline': 'off',
-    'object-curly-spacing': 'off',
+    'object-curly-spacing': ['error', 'always'],
     'object-property-newline': ['error', { allowMultiplePropertiesPerLine: true }],
     'one-var': ['error', { initialized: 'never' }],
     'operator-linebreak': 'off',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Currently allowed:

```js
const obj = {one: 'two'}
```

After this change:

```js
const obj = { one: 'two' }
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
