### PR TITLE
feat: allow common global/native extensions in tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,11 +18,9 @@ module.exports = {
   },
   overrides: [{
     files: ['test/**'],
-    globals: {
-      process: 'writable',
-    },
     rules: {
-      'no-extend-native': ['error', { exceptions: ['Date'] }],
+      'no-global-assign': 'off',
+      'no-extend-native': 'off',
     },
   }],
   rules: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,15 @@ module.exports = {
     navigator: 'readonly',
     window: 'readonly'
   },
+  overrides: [{
+    files: ['test/**'],
+    globals: {
+      process: 'writable',
+    },
+    rules: {
+      'no-extend-native': ['error', { exceptions: ['Date'] }],
+    },
+  }],
   rules: {
     'accessor-pairs': 'error',
     'array-bracket-spacing': ['error', 'never'],


### PR DESCRIPTION
We currently set these rules as `eslint-disable` directives in two places in `npm/cli`.

Is it worth codifying this rule across all our repos?
