### PR TITLE
fix: ignore tap-snapshots from linting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = {
     navigator: 'readonly',
     window: 'readonly',
   },
+  ignorePatterns: ['tap-snapshots/**'],
   overrides: [{
     files: ['test/**'],
     rules: {


### PR DESCRIPTION
We aren't linting thse files since our lint script is `eslint '**/*.js'` (and tap defaults to the extension `.cjs`) but this is a nice hint to other tools that these files are not linted.