### PR TITLE
fix: turn off promise/always-return

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -215,7 +215,7 @@ module.exports = {
     'import/no-duplicates': 'error',
 
     // promise plugin
-    'promise/always-return': 'error',
+    'promise/always-return': 'off',
     'promise/no-return-wrap': 'error',
     'promise/catch-or-return': 'error',
     'promise/no-new-statics': 'error',


### PR DESCRIPTION
I started [this PR](https://github.com/npm/cli/pull/5225) in the CLI to get a feel for how the new rules from #34 and this rule creates a lot of errors.

I can see how this helps avoid errors but we use Promises a lot for control flow that doesn't return a value. I suggest we turn this off.

Ref: https://github.com/xjamundx/eslint-plugin-promise/blob/development/docs/rules/always-return.md