### PR TITLE
fix: don't enforce max-len on comments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ module.exports = {
     'key-spacing': ['error', { beforeColon: false, afterColon: true }],
     'keyword-spacing': ['error', { before: true, after: true }],
     'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
-    'max-len': ['error', 100, { ignoreComments: false }],
+    'max-len': ['error', 100, { ignoreComments: true }],
     'new-cap': ['error', { newIsCap: true, capIsNew: false, properties: true }],
     'new-parens': 'error',
     'no-array-constructor': 'error',


### PR DESCRIPTION
Wrapping text content is not advised since it makes that text harder to read smoothly with screen readers.
