### PR TITLE
fix: set args to after-used for no-unused-vars rule

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -161,7 +161,7 @@ module.exports = {
     'no-unused-expressions': ['error', {
       allowShortCircuit: true, allowTernary: true, allowTaggedTemplates: true,
     }],
-    'no-unused-vars': ['error', { vars: 'all', args: 'none', ignoreRestSiblings: true }],
+    'no-unused-vars': ['error', { vars: 'all', args: 'after-used', ignoreRestSiblings: true }],
     'no-use-before-define': ['error', { functions: false, classes: false, variables: false }],
     'no-useless-call': 'error',
     'no-useless-computed-key': 'error',


### PR DESCRIPTION
This PR makes the following code failing linting. IMO this helps with refactoring and making sure arguments are not left in function calls.

```js
// Lint error: "'c' is defined but never used."
function unused (a, b, c) {
  return b
}
unused()
```

