### PR TITLE
fix: remove import/no-unresolved

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -221,7 +221,6 @@ module.exports = {
 
     // import plugin
     'import/no-extraneous-dependencies': 'error',
-    'import/no-unresolved': 'error',
     'import/no-duplicates': 'error',
 
     // promise plugin


### PR DESCRIPTION
This rule does not work with esm-only packages, and [it doesn't look like it ever will](https://github.com/import-js/eslint-plugin-import/issues/2331).  We'll remove it for now and rely on coverage in our tests for now
